### PR TITLE
Remove LootingBrain component on bot despawn

### DIFF
--- a/LootingBots/LootingBots.cs
+++ b/LootingBots/LootingBots.cs
@@ -265,6 +265,7 @@ namespace LootingBots
             ItemAppraiserLog = new Log(Logger, ItemAppraiserLogLevels);
 
             new SettingsAndCachePatch().Enable();
+            new RemoveComponent().Enable();
 
             BrainManager.RemoveLayer(
                 "Utility peace",

--- a/LootingBots/patches/RemoveComponent.cs
+++ b/LootingBots/patches/RemoveComponent.cs
@@ -1,0 +1,31 @@
+﻿using Aki.Reflection.Patching;
+using EFT;
+using LootingBots.Patch.Components;
+using System.Reflection;
+using UnityEngine;
+
+namespace LootingBots.Patch
+{
+    internal class RemoveComponent : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return typeof(BotControllerClass).GetMethod(
+                "Init",
+                BindingFlags.Public | BindingFlags.Instance
+            );
+        }
+
+        [PatchPostfix]
+        private static void PatchPostfix(BotControllerClass __instance)
+        {
+            __instance.BotSpawner.OnBotRemoved += botOwner =>
+            {
+                if (botOwner.GetPlayer.TryGetComponent<LootingBrain>(out var component))
+                {
+                    Object.Destroy(component);
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
When bots are despawned, their component is re-used for later bots. This was resulting in multiple LootingBrain components being applied to bots later in raid. Add a new patch that destroys the component on bot removal