### PR TITLE
Fix bots not reloading

### DIFF
--- a/LootingBots/components/TransactionController.cs
+++ b/LootingBots/components/TransactionController.cs
@@ -11,6 +11,8 @@ using LootingBots.Patch.Util;
 
 using InventoryOperationResultStruct = GStruct370;
 using InventoryHelperClass = GClass2672;
+using GridClassEx = GClass2411;
+using GridCacheClass = GClass1384;
 
 namespace LootingBots.Patch.Components
 {
@@ -143,6 +145,7 @@ namespace LootingBots.Patch.Components
                             else
                             {
                                 ammoAdded += ammo.StackObjectsCount;
+                                Singleton<GridCacheClass>.Instance.Add(location.GetOwner().ID, location.Grid as GridClassEx, ammo);
                             }
                         }
                         else

--- a/LootingBots/utils/LootUtils.cs
+++ b/LootingBots/utils/LootUtils.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using Comfort.Common;
+
 using EFT;
 using EFT.Interactive;
 using EFT.InventoryLogic;
@@ -8,12 +10,14 @@ using EFT.InventoryLogic;
 using UnityEngine;
 
 using GridClass = GClass2408;
+using GridClassEx = GClass2411;
 using InteractResultClass = GClass2846;
 using GridManagerClass = GClass2706;
 using SortResultStruct = GStruct371<GClass2706>;
 using GridItemClass = GClass2416;
 using ItemAddressExClass = GClass2667;
 using SortErrorClass = GClass3103;
+using GridCacheClass = GClass1384;
 
 namespace LootingBots.Patch.Util
 {
@@ -78,6 +82,7 @@ namespace LootingBots.Patch.Util
                     gridManager.SetOldPositions(grid, grid.ItemCollection.ToListOfLocations());
                     itemsInContainer.AddRange(grid.Items);
                     grid.RemoveAll();
+                    Singleton<GridCacheClass>.Instance.Set(container.Owner.ID, grid as GridClassEx, new string[] { });
                     controller.RaiseEvent(new GEventArgs23(grid));
                 }
 
@@ -108,6 +113,7 @@ namespace LootingBots.Patch.Util
                                     ((ItemAddressExClass)item.CurrentAddress).LocationInGrid
                                 )
                             );
+                            Singleton<GridCacheClass>.Instance.Add(container.Owner.ID, grid as GridClassEx, item);
                             break;
                         }
                     }


### PR DESCRIPTION
3.6.0 has a new grid cache system, make sure we update its state when sorting bot rigs and adding ammo to the secure container