### PR TITLE
Fix Player Scav Detection [SPT 3.11]

### DIFF
--- a/LootingBots/components/LootingBrain.cs
+++ b/LootingBots/components/LootingBrain.cs
@@ -134,7 +134,16 @@ namespace LootingBots.Patch.Components
             InventoryController = new LootingInventoryController(BotOwner, this);
             IgnoredLootIds = new List<string> { };
             NonNavigableLootIds = new List<string> { };
-            IsPlayerScav = botOwner.Profile.Nickname.Contains(" (");
+        }
+
+        /*
+        * Automatically called as this MonoBehaviour begins running.
+        * 
+        * IMPORTANT: IsPlayerScav MUST be updated after Init() because SPT changes the WildSpawnType for player Scavs after that method is called.
+        */
+        public void Start()
+        {
+            IsPlayerScav = WillBeAPlayerScav(BotOwner.Profile);
             _performanceTimer = Time.time + PeformanceTimerInterval;
             ActiveLootCache.Init();
 
@@ -143,7 +152,7 @@ namespace LootingBots.Patch.Components
                 // If there is space in the BotCache, add the bot to the cache. Otherwise disable the looting brain until there is space available in the cache
                 if (ForceBrainEnabled || (ActiveBotCache.IsAbleToCache && _isCloseToPlayer))
                 {
-                    ActiveBotCache.Add(botOwner);
+                    ActiveBotCache.Add(BotOwner);
                 }
                 else
                 {
@@ -531,6 +540,21 @@ namespace LootingBots.Patch.Components
 
             ActiveLootCache.Cleanup(BotOwner);
             ActiveCorpse = null;
+        }
+
+        /**
+        * Determines if the bot with the given profile will be a player Scav
+        */
+        public bool WillBeAPlayerScav(Profile profile)
+        {
+            // Handle the old version of creating player Scavs
+            if (profile.Info.Nickname.Contains(" ("))
+            {
+                return true;
+            }
+
+            // Check for player Scavs created by SPT
+            return profile.Info.Settings.Role == WildSpawnType.assault && !string.IsNullOrEmpty(profile.Info.MainProfileNickname);
         }
     }
 }


### PR DESCRIPTION
Fixed player Scav detection to work with the new system in SPT 3.11 that adds PMC nicknames to the bot's profile instead appending it in parenthesis.

This is especially needed for Questing Bots, which now uses the new SPT 3.11 method of generating player Scavs. 