### PR TITLE
Bug Fix for Infinite Looting Loop

### DIFF
--- a/LootingBots/Logic/FindLootLogic.cs
+++ b/LootingBots/Logic/FindLootLogic.cs
@@ -23,8 +23,16 @@ namespace LootingBots.Logic
 
         public override void Update(CustomLayer.ActionData data)
         {
+            if (!_lootingBrain.HasFreeSpace)
+            {
+                // Need to disable LockUntilNextScan if the bot has no free space to prevent an infinite looting loop
+                _lootFinder.LockUntilNextScan = false;
+
+                return;
+            }
+
             // Trigger a scan if one is not running already
-            if (_lootingBrain.HasFreeSpace && !_lootFinder.IsScanRunning)
+            if (!_lootFinder.IsScanRunning)
             {
                 if (_log.DebugEnabled)
                 {


### PR DESCRIPTION
Fixed bug causing bots to be stuck in an infinite looting loop if they're forced to scan for loot (typically by Questing Bots) but they have no free space.

I didn't put this fix in `External.ForceBotToScanLoot()` because both `LootFinder.ForceScan()` and `LootFinder.OverrideNextScanTime()` set `LockUntilNextScan` to true. I figured putting it here would be safer. Feel free to refactor if you think there's a better way of doing this. 