### PR TITLE
LOS for specific bot type

### DIFF
--- a/LootingBots/Components/LootFinder.cs
+++ b/LootingBots/Components/LootFinder.cs
@@ -1,6 +1,5 @@
 using System.Buffers;
 using Comfort.Common;
-using Dissonance;
 using EFT;
 using EFT.Interactive;
 using EFT.InventoryLogic;
@@ -30,8 +29,11 @@ public class LootFinder : MonoBehaviour
 
     // Bot specific config
     private bool _containerLootingEnabled;
+    private bool _needsContainerSight;
     private bool _itemLootingEnabled;
+    private bool _needsItemSight;
     private bool _corpseLootingEnabled;
+    private bool _needsCorpseSight;
 
     public bool IsScheduledScan
     {
@@ -75,8 +77,11 @@ public class LootFinder : MonoBehaviour
         _log = new BotLog(LootingBots.LootLog, _botOwner);
 
         _containerLootingEnabled = LootingBots.ContainerLootingEnabled.Value.IsBotEnabled(_lootingBrain);
+        _needsContainerSight = LootingBots.DetectContainerNeedsSight.Value.IsBotEnabled(_lootingBrain);
         _itemLootingEnabled = LootingBots.LooseItemLootingEnabled.Value.IsBotEnabled(_lootingBrain);
+        _needsItemSight = LootingBots.DetectItemNeedsSight.Value.IsBotEnabled(_lootingBrain);
         _corpseLootingEnabled = LootingBots.CorpseLootingEnabled.Value.IsBotEnabled(_lootingBrain);
+        _needsCorpseSight = LootingBots.DetectCorpseNeedsSight.Value.IsBotEnabled(_lootingBrain);
 
         if (_containerLootingEnabled)
         {
@@ -520,9 +525,9 @@ public class LootFinder : MonoBehaviour
     {
         var needsSight = lootType switch
         {
-            LootType.Corpse => LootingBots.DetectCorpseNeedsSight.Value,
-            LootType.Container => LootingBots.DetectContainerNeedsSight.Value,
-            LootType.Item => LootingBots.DetectItemNeedsSight.Value,
+            LootType.Corpse => _needsCorpseSight,
+            LootType.Container => _needsContainerSight,
+            LootType.Item => _needsItemSight,
             LootType.None => throw new ArgumentOutOfRangeException(nameof(lootType), lootType, null),
             _ => throw new ArgumentOutOfRangeException(nameof(lootType), lootType, null),
         };

--- a/LootingBots/LootingBots.cs
+++ b/LootingBots/LootingBots.cs
@@ -43,11 +43,11 @@ public class LootingBots : BaseUnityPlugin
 
     public static ConfigEntry<float> LootScanInterval;
     public static ConfigEntry<float> DetectItemDistance;
-    public static ConfigEntry<bool> DetectItemNeedsSight;
+    public static ConfigEntry<BotType> DetectItemNeedsSight;
     public static ConfigEntry<float> DetectContainerDistance;
-    public static ConfigEntry<bool> DetectContainerNeedsSight;
+    public static ConfigEntry<BotType> DetectContainerNeedsSight;
     public static ConfigEntry<float> DetectCorpseDistance;
-    public static ConfigEntry<bool> DetectCorpseNeedsSight;
+    public static ConfigEntry<BotType> DetectCorpseNeedsSight;
 
     public static ConfigEntry<bool> DebugLootNavigation;
     public static ConfigEntry<LogLevel> LootingLogLevels;
@@ -100,9 +100,9 @@ public class LootingBots : BaseUnityPlugin
         DetectCorpseNeedsSight = Config.Bind(
             "Loot Finder",
             "Enable corpse line of sight check",
-            false,
+            BotType.None,
             new ConfigDescription(
-                "When scanning for loot, corpses will be ignored if they are not visible by the bot",
+                "When scanning for loot, corpses will be ignored if they are not visible for the selected bot types. Takes effect next raid",
                 null,
                 new ConfigurationManagerAttributes { Order = 9 }
             )
@@ -131,9 +131,9 @@ public class LootingBots : BaseUnityPlugin
         DetectContainerNeedsSight = Config.Bind(
             "Loot Finder",
             "Enable container line of sight check",
-            false,
+            BotType.None,
             new ConfigDescription(
-                "When scanning for loot, containers will be ignored if they are not visible by the bot",
+                "When scanning for loot, containers will be ignored if they are not visible for the selected bot types. Takes effect next raid",
                 null,
                 new ConfigurationManagerAttributes { Order = 6 }
             )
@@ -162,9 +162,9 @@ public class LootingBots : BaseUnityPlugin
         DetectItemNeedsSight = Config.Bind(
             "Loot Finder",
             "Enable item line of sight check",
-            false,
+            BotType.None,
             new ConfigDescription(
-                "When scanning for loot, loose items will be ignored if they are not visible by the bot",
+                "When scanning for loot, loose items will be ignored if they are not visible for the selected bot types. Takes effect next raid",
                 null,
                 new ConfigurationManagerAttributes { Order = 3 }
             )

--- a/LootingBots/Utilities/BotTypes.cs
+++ b/LootingBots/Utilities/BotTypes.cs
@@ -15,6 +15,7 @@ public enum BotType
     Follower = 64,
     Bloodhound = 128,
 
+    None = 0,
     All = Scav | Pmc | PlayerScav | Raider | Cultist | Boss | Follower | Bloodhound,
 }
 


### PR DESCRIPTION
More user configurability for `IsLootInSight` checks.

Use case is: Maybe PMCs and PScavs don't need LOS for loose items, but the rest do
